### PR TITLE
Add bundle transmission size `limit` option

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,8 +21,11 @@ app.log = log;
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded());
+var bodyParserOptions = {
+  limit: conf.get('limit') + 'kb'
+};
+app.use(bodyParser.json(bodyParserOptions));
+app.use(bodyParser.urlencoded(bodyParserOptions));
 
 app.post('/freight/check', freightRoutes.check);
 app.post('/freight/download', freightRoutes.download);

--- a/config/config.js
+++ b/config/config.js
@@ -37,6 +37,11 @@ module.exports = function () {
       default: 8872,
       env: 'PORT'
     },
+    limit: {
+      doc: 'The bundle transmission size limit, in kb.',
+      format: 'nat',
+      default: 500
+    },
     password: {
       doc: 'The password that is used to create Freight bundles.',
       format: String,


### PR DESCRIPTION
`bodyParser` has a default limit of [`100kb`](https://github.com/expressjs/body-parser#limit), which is not quite large enough for ambitiously-sized Node.js applications.

(For example, a boilerplate Ember.js application generated with `ember-cli` is about 325kb.)

This PR adds a configuration option (`limit`) to control this value, and raises it from the default to 500kb.

I'm adding better error handling to the CLI in a separate PR.

CC: @michelle @slexaxton