### PR TITLE
Update bower to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "archiver": "0.9.1",
     "async": "0.9.0",
     "body-parser": "1.0.0",
-    "bower": "1.3.8",
+    "bower": "1.4.1",
     "bunyan": "0.22.3",
     "convict": "0.4.2",
     "express": "3.17.4",


### PR DESCRIPTION
`bower` was misbehaving—specifically, it wasn't respecting the non-interactive flag, which was causing it to hang. Bumping to latest seemed to fix it.